### PR TITLE
feat: Make hero title's dynamic word responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -1060,6 +1060,24 @@
             #hero h1 {
                 font-size: 2.8em; /* Kleinere titel */
             }
+
+            #hero h1 .dynamic-word-container {
+                display: block;
+                margin: 0.2em auto;
+                width: auto !important;
+                text-align: center;
+            }
+
+            #hero h1 .dynamic-word {
+                right: auto;
+                left: 50%;
+                transform: translateX(-50%) translateY(100%);
+            }
+
+            #hero h1 .dynamic-word.active {
+                transform: translateX(-50%) translateY(0);
+            }
+
             #hero p {
                 font-size: 1.1em; /* Kleinere paragraaf */
             }
@@ -2237,6 +2255,7 @@
             tempSpan.style.fontWeight = h1Style.fontWeight;
             tempSpan.style.fontFamily = h1Style.fontFamily;
             tempSpan.style.color = 'var(--dynamic-word-tint)';
+            tempSpan.style.padding = '0 8px'; // Match the container's padding
 
             document.body.appendChild(tempSpan);
 


### PR DESCRIPTION
This commit addresses an issue where the changing word in the hero section title did not display correctly on all devices.

The changes include:
1.  **JavaScript:** The `calculateMaxWordWidth` function has been updated to include the container's horizontal padding in its calculation. This ensures the container is always wide enough to prevent longer words from being clipped on desktop.
2.  **CSS:** New rules have been added within a `@media` query for mobile screens (`max-width: 768px`). These rules change the dynamic word container to a block element and center it horizontally on its own line, fulfilling the mobile design requirement.